### PR TITLE
Add support for checking which ROM is loaded.

### DIFF
--- a/src/PokemonROMEditor/Models/Enums.cs
+++ b/src/PokemonROMEditor/Models/Enums.cs
@@ -27,6 +27,18 @@ namespace PokemonROMEditor.Models
     };
     //*/
 
+    public enum GameType
+    {
+        Unknown = 0,
+        Red = 1,
+        Blue = 2,
+        Green = 3,
+        Yellow = 4,
+        Gold = 5,       // Added unsupported games for future-proofing
+        Silver = 6,
+        Crystal = 7
+    }
+
     public enum EvolveType
     {
         NONE = 0,

--- a/src/PokemonROMEditor/Models/ROMConverter.cs
+++ b/src/PokemonROMEditor/Models/ROMConverter.cs
@@ -15,6 +15,8 @@ namespace PokemonROMEditor.Models
         private Dictionary<int, int> PokedexIDs;
         private Dictionary<int, int> IndexIDs;
 
+        int gameNameStartByte = 0x134; // Game name (eg. POKEMON RED     ) starts at 0x134 and ends at 0x142
+
         int mapHeaderPointersByte = 430; // 0x1AE 
         int shopsStartByte = 9282; //The data for the pokemarts inventories starts at byte 0x2442
         int mewStartByte = 16987; // Mew's stats start at byte 0x425B
@@ -76,6 +78,52 @@ namespace PokemonROMEditor.Models
             SavePokeTypes(types);
             // then just write the new byte array to file.
             File.WriteAllBytes(fileName, romData);
+        }
+
+        public GameType LoadRomName()
+        {
+            string name = "";
+            byte[] readBytes = new byte[16];
+            byte readByte;
+
+            // Read each character into bytes to then convert to string. Game name is encoded in plain ASCII, unlike other strings in the ROM.
+            for (int i = 0; i < 16; i++)
+            {
+                readByte = romData[i + gameNameStartByte];
+                if (readByte == 0)
+                    readBytes[i] = 32;  // Replace null char with space so we can trim it later.
+                else
+                    readBytes[i] = readByte;
+            }
+            name = Encoding.ASCII.GetString(readBytes).Trim();
+
+            // Associate each identifier to a game
+            switch (name)
+            {
+                case "POKEMON RED":
+                    return GameType.Red;
+
+                case "POKEMON BLUE":
+                    return GameType.Blue;
+
+                case "POKEMON YELLOW":
+                    return GameType.Yellow;
+
+                case "POKEMON GREEN":
+                    return GameType.Green;
+
+                /* Unimplemented games
+                case "POKEMON_GLDAAUE":
+                    return GameType.Gold;
+                case "POKEMON_SLVAAXE":
+                    return GameType.Silver;
+                case "PM_CRYSTAL BYTE":
+                    return GameType.Crystal;                 
+                */
+
+                default:
+                    return GameType.Unknown;
+            }
         }
 
         public ObservableCollection<Move> LoadMoves()
@@ -563,6 +611,7 @@ namespace PokemonROMEditor.Models
 
             return typeStrengths;
         }
+
 
         private void SaveTypeStrengths(ObservableCollection<TypeStrength> str)
         {

--- a/src/PokemonROMEditor/PokemonROMEditor.csproj
+++ b/src/PokemonROMEditor/PokemonROMEditor.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B2C84D30-3766-452A-9EA2-6BAFBCDEE41C}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <RootNamespace>PokemonROMEditor</RootNamespace>
     <AssemblyName>PokemonROMEditor</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
@@ -36,6 +36,9 @@
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>pokeball_resized.ico</ApplicationIcon>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/PokemonROMEditor/ViewModels/ROMEditorViewModel.cs
+++ b/src/PokemonROMEditor/ViewModels/ROMEditorViewModel.cs
@@ -35,7 +35,10 @@ namespace PokemonROMEditor.ViewModels
 
         public string RomFile
         {
-            get { return romFile; }
+            get
+            {
+                return romFile;
+            }
         }
 
         public string ToggleButtonText
@@ -53,6 +56,17 @@ namespace PokemonROMEditor.ViewModels
                 
             }
             
+        }
+
+        private GameType gameName;
+
+        public GameType GameName
+        {
+            get { return gameName; }
+            set
+            {
+                gameName = value;
+            }
         }
 
         private ObservableCollection<Move> moves;
@@ -1146,6 +1160,7 @@ namespace PokemonROMEditor.ViewModels
                 OnPropertyChanged("RomFile");
                 //load data from ROM
                 await Task.Run(() => romConverter.LoadROMDataFromFile(romFile));
+                GameName = romConverter.LoadRomName();
                 PokeTypes = romConverter.LoadPokeTypes();
                 Moves = romConverter.LoadMoves();
                 Pokemons = romConverter.LoadPokemon();


### PR DESCRIPTION
New enum GameType (class ROMEditorViewModel has it as a field) tells us which game is loaded.
Still unsure on what this will be used for immediately, but will eventually allow the implementation of more games, notably Gen II.